### PR TITLE
Support latest ReactPHP stream version and strictly follow stream semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ tar stream into the `Decoder` which emits "entry" events for each individual fil
 
 ```php
 $loop = React\EventLoop\Factory::create();
-$stream = new Stream(fopen('archive.tar', 'r'), $loop);
+$stream = new ReadableResourceStream(fopen('archive.tar', 'r'), $loop);
 
 $decoder = new Decoder();
 
 $decoder->on('entry', function ($header, ReadableStreamInterface $file) {
     echo 'File ' . $header['filename'];
     echo ' (' . $header['size'] . ' bytes):' . PHP_EOL;
-    
+
     $file->on('data', function ($chunk) {
         echo $chunk;
     });

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $stream = new ReadableResourceStream(fopen('archive.tar', 'r'), $loop);
 
 $decoder = new Decoder();
 
-$decoder->on('entry', function ($header, ReadableStreamInterface $file) {
+$decoder->on('entry', function (array $header, React\Stream\ReadableStreamInterface $file) {
     echo 'File ' . $header['filename'];
     echo ' (' . $header['size'] . ' bytes):' . PHP_EOL;
 

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,11 @@
     ],
     "require": {
         "php": ">=5.3",
-        "react/stream": "^1 || ^0.7 || ^0.6"
+        "react/stream": "^1.0 || ^0.7 || ^0.6"
     },
     "require-dev": {
         "clue/hexdump": "~0.2.0",
-        "react/event-loop": "^1",
-        "react/promise": "~2.0|~1.0",
-        "react/promise-stream": "^1",
+        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
         "phpunit/phpunit": "^7.0 || ^6.0 || ^5.0 || ^4.8.35"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,13 @@
     ],
     "require": {
         "php": ">=5.3",
-        "react/stream": "~0.4.0|~0.3.0"
+        "react/stream": "^1 || ^0.7 || ^0.6"
     },
     "require-dev": {
         "clue/hexdump": "~0.2.0",
-        "react/event-loop": "~0.4.0|~0.3.0",
+        "react/event-loop": "^1",
         "react/promise": "~2.0|~1.0",
+        "react/promise-stream": "^1",
         "phpunit/phpunit": "^7.0 || ^6.0 || ^5.0 || ^4.8.35"
     },
     "autoload": {

--- a/examples/dump.php
+++ b/examples/dump.php
@@ -2,37 +2,35 @@
 
 use Clue\Hexdump\Hexdump;
 use Clue\React\Tar\Decoder;
-use React\EventLoop\StreamSelectLoop;
+use React\EventLoop\Factory;
 use React\Stream\ReadableResourceStream;
-use React\Promise\Stream;
+use React\Stream\ReadableStreamInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $in = isset($argv[1]) ? $argv[1] : (__DIR__ . '/../tests/fixtures/alice-bob.tar');
 echo 'Reading file "' . $in . '" (pass as argument to example)' . PHP_EOL;
 
-// using the default loop does *not* work for file I/O
-//$loop = Factory::create();
-$loop = new StreamSelectLoop();
-
+$loop = Factory::create();
 $stream = new ReadableResourceStream(fopen($in, 'r'), $loop);
 
 $decoder = new Decoder();
-$decoder->on('entry', function ($header, $file) {
+$decoder->on('entry', function (array $header, ReadableStreamInterface $file) {
     static $i = 0;
     echo 'FILE #' . ++$i . PHP_EOL;
-
 
     echo 'Received entry headers:' . PHP_EOL;
     var_dump($header);
 
-    Stream\buffer($file)->then(function ($contents) {
+    $contents = '';
+    $file->on('data', function ($chunk) use (&$contents) {
+        $contents .= $chunk;
+    });
+    $file->on('close', function () use (&$contents) {
         echo 'Received entry contents (' . strlen($contents) . ' bytes)' . PHP_EOL;
 
         $d = new Hexdump();
         echo $d->dump($contents) . PHP_EOL . PHP_EOL;
-    }, function ($error) {
-        echo 'ERROR: ' . $error . PHP_EOL;
     });
 });
 $decoder->on('error', function ($error) {

--- a/src/Decoder.php
+++ b/src/Decoder.php
@@ -2,10 +2,11 @@
 
 namespace Clue\React\Tar;
 
-use React\Stream\WritableStream;
-use React\Stream\ReadableStream;
-use RuntimeException;
+use Evenement\EventEmitter;
 use Exception;
+use React\Stream\ThroughStream;
+use React\Stream\WritableStreamInterface;
+use RuntimeException;
 
 /**
  * Decodes a TAR stream and emits "entry" events for each individual file in the archive.
@@ -14,11 +15,11 @@ use Exception;
  * introduced by POSIX IEEE P1003.1. In the future, it should support more of
  * the less common alternative formats.
  *
- * @event entry(array $header, ReadableStream $stream, Decoder $thisDecoder)
+ * @event entry(array $header, \React\Stream\ReadableStreamInterface $stream, Decoder $thisDecoder)
  * @event error(Exception $e, Decoder $thisDecoder)
  * @event close()
  */
-class Decoder extends WritableStream
+class Decoder extends EventEmitter implements WritableStreamInterface
 {
     private $buffer = '';
     private $writable = true;
@@ -89,7 +90,7 @@ class Decoder extends WritableStream
                 return;
             }
 
-            $this->streaming = new ReadableStream();
+            $this->streaming = new ThroughStream();
             $this->remaining = $header['size'];
             $this->padding   = $header['padding'];
 

--- a/tests/DecoderTest.php
+++ b/tests/DecoderTest.php
@@ -3,6 +3,8 @@
 namespace Clue\Tests\React\Tar;
 
 use Clue\React\Tar\Decoder;
+use React\Stream\ThroughStream;
+use React\Stream\ReadableStreamInterface;
 
 class DecoderTest extends TestCase
 {
@@ -13,30 +15,171 @@ class DecoderTest extends TestCase
         $this->decoder = new Decoder();
     }
 
-    public function testWritingLessDataThanBufferSizeWillNotEmitAnyEvents()
+    public function testWriteLessDataThanBufferSizeWillNotEmitAnyEvents()
     {
         $this->decoder->on('entry', $this->expectCallableNever());
         $this->decoder->on('close', $this->expectCallableNever());
 
-        $this->decoder->write('data');
+        $ret = $this->decoder->write('data');
+
+        $this->assertTrue($ret);
     }
 
-    public function testWritingInvalidDataWillEmitError()
+    public function testWriteInvalidDataWillEmitErrorAndReturnFalse()
     {
         $this->decoder->on('error', $this->expectCallableOnce());
         $this->decoder->on('close', $this->expectCallableOnce());
 
-        $this->decoder->write(str_repeat('2', 1024));
+        $ret = $this->decoder->write(str_repeat('2', 1024));
+
+        $this->assertFalse($ret);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testWritingToClosedDecoderDoesNothing()
+    public function testWriteInvalidDataWithValidHeaderButInvalidChecksumWillEmitErrorAndReturnFalse()
+    {
+        $this->decoder->on('error', $this->expectCallableOnce());
+        $this->decoder->on('close', $this->expectCallableOnce());
+
+        $data = 'x' . file_get_contents(__DIR__ . '/fixtures/alice-bob.tar', false, null, 1, 512 - 1);
+        $ret = $this->decoder->write($data);
+
+        $this->assertFalse($ret);
+    }
+
+    public function testWriteToClosedDecoderDoesNothing()
     {
         $this->decoder->close();
 
-        $this->decoder->write(str_repeat('x', 1024));
+        $ret = $this->decoder->write(str_repeat('x', 1024));
+
+        $this->assertFalse($ret);
+    }
+
+    public function testWriteDataExactlyOneBlockWillDecodeHeaderAndStartStreamingEntry()
+    {
+        $never = $this->expectCallableNever();
+        $this->decoder->on('entry', function (array $header, ReadableStreamInterface $stream) use ($never) {
+            $stream->on('end', $never);
+            $stream->on('close', $never);
+        });
+        $this->decoder->on('entry', $this->expectCallableOnce());
+
+        $data = file_get_contents(__DIR__ . '/fixtures/alice-bob.tar', false, null, 0, 512);
+        $ret = $this->decoder->write($data);
+
+        $this->assertTrue($ret);
+    }
+
+    public function testWriteDataOneBlockPlusDataAndIncompletePaddingWillDecodeHeaderAndEndAndCloseEntryAndAwaitMorePadding()
+    {
+        $data = $this->expectCallableOnceWith("bob\n");
+        $end = $this->expectCallableOnce();
+        $close = $this->expectCallableOnce();
+        $this->decoder->on('entry', function (array $header, ReadableStreamInterface $stream) use ($data, $end, $close) {
+            $stream->on('data', $data);
+            $stream->on('end', $end);
+            $stream->on('close', $close);
+        });
+        $this->decoder->on('entry', $this->expectCallableOnce());
+
+        $data = file_get_contents(__DIR__ . '/fixtures/alice-bob.tar', false, null, 0, 512 + 10);
+        $ret = $this->decoder->write($data);
+
+        $this->assertTrue($ret);
+
+        $ref = new \ReflectionProperty($this->decoder, 'padding');
+        $ref->setAccessible(true);
+
+        $this->assertEquals(512 - 10, $ref->getValue($this->decoder));
+    }
+
+    public function testWriteDataExactlyOneBlockWithEmptyFileEntryWillDecodeHeaderAndImmediatelyEndAndCloseEntry()
+    {
+        $data = $this->expectCallableNever();
+        $end = $this->expectCallableOnce();
+        $close = $this->expectCallableOnce();
+        $this->decoder->on('entry', function (array $header, ReadableStreamInterface $stream) use ($data, $end, $close) {
+            $stream->on('data', $data);
+            $stream->on('end', $end);
+            $stream->on('close', $close);
+        });
+        $this->decoder->on('entry', $this->expectCallableOnce());
+
+        $data = file_get_contents(__DIR__ . '/fixtures/single-empty.tar', false, null, 0, 512);
+        $ret = $this->decoder->write($data);
+
+        $this->assertTrue($ret);
+    }
+
+    public function testWriteDataWhenStreamingEntryWillEmitDataOnEntryWithoutEndWhenMoreDataIsRemaining()
+    {
+        $entry = new ThroughStream();
+        $entry->on('data', $this->expectCallableOnceWith('hi'));
+        $entry->on('end', $this->expectCallableNever());
+        $entry->on('close', $this->expectCallableNever());
+
+        $ref = new \ReflectionProperty($this->decoder, 'streaming');
+        $ref->setAccessible(true);
+        $ref->setValue($this->decoder, $entry);
+
+        $ref = new \ReflectionProperty($this->decoder, 'remaining');
+        $ref->setAccessible(true);
+        $ref->setValue($this->decoder, 100);
+
+        $ret = $this->decoder->write('hi');
+
+        $this->assertTrue($ret);
+    }
+
+    public function testWriteDataWhenStreamingEntryWillEmitDataOnEntryAndEndAndCloseWhenRemainingDataIsMatched()
+    {
+        $entry = new ThroughStream();
+        $entry->on('data', $this->expectCallableOnceWith('hi'));
+        $entry->on('end', $this->expectCallableOnce());
+        $entry->on('close', $this->expectCallableOnce());
+
+        $ref = new \ReflectionProperty($this->decoder, 'streaming');
+        $ref->setAccessible(true);
+        $ref->setValue($this->decoder, $entry);
+
+        $ref = new \ReflectionProperty($this->decoder, 'remaining');
+        $ref->setAccessible(true);
+        $ref->setValue($this->decoder, 2);
+
+        $ret = $this->decoder->write('hi');
+
+        $this->assertTrue($ret);
+    }
+
+    public function testWriteDataWhenExpectingPaddingWillDiscardPaddingDataWhenMorePaddingIsExpected()
+    {
+        $ref = new \ReflectionProperty($this->decoder, 'padding');
+        $ref->setAccessible(true);
+        $ref->setValue($this->decoder, 4);
+
+        $ret = $this->decoder->write("\x00\x00");
+
+        $this->assertTrue($ret);
+
+        $this->assertEquals(2, $ref->getValue($this->decoder));
+    }
+
+    public function testWriteDataWhenExpectingPaddingWillDiscardPaddingDataAndSaveToBufferWhenPaddingIsMatched()
+    {
+        $ref = new \ReflectionProperty($this->decoder, 'padding');
+        $ref->setAccessible(true);
+        $ref->setValue($this->decoder, 1);
+
+        $ret = $this->decoder->write("\x00\x00");
+
+        $this->assertTrue($ret);
+
+        $this->assertEquals(0, $ref->getValue($this->decoder));
+
+        $ref = new \ReflectionProperty($this->decoder, 'buffer');
+        $ref->setAccessible(true);
+
+        $this->assertEquals("\x00", $ref->getValue($this->decoder));
     }
 
     public function testClosingWillMakeItNoLongerWritable()
@@ -54,6 +197,8 @@ class DecoderTest extends TestCase
         $this->decoder->on('error', $this->expectCallableNever());
 
         $this->decoder->close();
+
+        $this->assertEquals(array(), $this->decoder->listeners('close'));
     }
 
     public function testClosingTwiceWillEmitCloseEventOnce()
@@ -64,13 +209,57 @@ class DecoderTest extends TestCase
         $this->decoder->close();
     }
 
-    public function testClosingWithPendingDataWillEmitErrorAndCloseEvent()
+    public function testCloseWithPendingDataWillCloseWithoutEmittingError()
     {
-        $this->decoder->write('data');
+        $this->decoder->on('error', $this->expectCallableNever());
+        $this->decoder->on('close', $this->expectCallableOnce());
 
+        $this->decoder->write('data');
+        $this->decoder->close();
+    }
+
+    public function testCloseWhenStreamingEntryWillEmitCloseOnEntryAndOnDecoder()
+    {
+        $this->decoder->on('error', $this->expectCallableNever());
+        $this->decoder->on('close', $this->expectCallableOnce());
+
+        $entry = new ThroughStream();
+        $entry->on('data', $this->expectCallableNever());
+        $entry->on('end', $this->expectCallableNever());
+        $entry->on('error', $this->expectCallableNever());
+        $entry->on('close', $this->expectCallableOnce());
+
+        $ref = new \ReflectionProperty($this->decoder, 'streaming');
+        $ref->setAccessible(true);
+        $ref->setValue($this->decoder, $entry);
+
+        $this->decoder->close();
+    }
+
+    public function testEndWithPendingDataWillEmitErrorAndClose()
+    {
         $this->decoder->on('error', $this->expectCallableOnce());
         $this->decoder->on('close', $this->expectCallableOnce());
 
-        $this->decoder->close();
+        $this->decoder->write('data');
+        $this->decoder->end();
+    }
+
+    public function testEndWhenStreamingEntryWillEmitErrorAndCloseOnEntryAndOnDecoder()
+    {
+        $this->decoder->on('error', $this->expectCallableOnce());
+        $this->decoder->on('close', $this->expectCallableOnce());
+
+        $entry = new ThroughStream();
+        $entry->on('data', $this->expectCallableNever());
+        $entry->on('end', $this->expectCallableNever());
+        $entry->on('error', $this->expectCallableOnce());
+        $entry->on('close', $this->expectCallableOnce());
+
+        $ref = new \ReflectionProperty($this->decoder, 'streaming');
+        $ref->setAccessible(true);
+        $ref->setValue($this->decoder, $entry);
+
+        $this->decoder->end();
     }
 }

--- a/tests/FunctionalDecoderTest.php
+++ b/tests/FunctionalDecoderTest.php
@@ -4,7 +4,7 @@ namespace Clue\Tests\React\Tar;
 
 use Clue\React\Tar\Decoder;
 use React\EventLoop\StreamSelectLoop;
-use React\Stream\Stream;
+use React\Stream\ReadableResourceStream;
 
 class FunctionDecoderTest extends TestCase
 {
@@ -33,10 +33,8 @@ class FunctionDecoderTest extends TestCase
      */
     public function testAliceBobWithSmallBufferSize()
     {
-        $stream = $this->createStream('alice-bob.tar');
-
         // a tiny buffer size will emit *lots* of individual chunks, but the parser should work as expected
-        $stream->bufferSize = 11;
+        $stream = $this->createStream('alice-bob.tar', 11);
 
         $stream->pipe($this->decoder);
 
@@ -80,8 +78,8 @@ class FunctionDecoderTest extends TestCase
         $this->decoder->end(file_get_contents(__DIR__ . '/fixtures/single-empty.tar'));
     }
 
-    private function createStream($name)
+    private function createStream($name, $readChunkSize = null)
     {
-        return new Stream(fopen(__DIR__ . '/fixtures/' . $name, 'r'), $this->loop);
+        return new ReadableResourceStream(fopen(__DIR__ . '/fixtures/' . $name, 'r'), $this->loop, $readChunkSize);
     }
 }

--- a/tests/FunctionalDecoderTest.php
+++ b/tests/FunctionalDecoderTest.php
@@ -3,7 +3,7 @@
 namespace Clue\Tests\React\Tar;
 
 use Clue\React\Tar\Decoder;
-use React\EventLoop\StreamSelectLoop;
+use React\EventLoop\Factory;
 use React\Stream\ReadableResourceStream;
 
 class FunctionDecoderTest extends TestCase
@@ -13,7 +13,7 @@ class FunctionDecoderTest extends TestCase
     public function setUp()
     {
         $this->decoder = new Decoder();
-        $this->loop = new StreamSelectLoop();
+        $this->loop = Factory::create();
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,17 @@ class TestCase extends \PHPUnit\Framework\TestCase
         return $mock;
     }
 
+    protected function expectCallableOnceWith($value)
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($value);
+
+        return $mock;
+    }
+
     protected function expectCallableNever()
     {
         $mock = $this->createCallableMock();


### PR DESCRIPTION
The `entry` event will now always be invoked with a `ReadableStreamInterface` instead of the legacy `ReadableStream`. Simply update your code to use the new type declaration and it should be compatible with both the old and the new version.

Supersedes / closes #8, thanks @dontub for the original changes!