### PR TITLE
Simplify examples and tests by updating to new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ Once [installed](#install), you can use the following code to pipe a readable
 tar stream into the `Decoder` which emits "entry" events for each individual file:
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$stream = new ReadableResourceStream(fopen('archive.tar', 'r'), $loop);
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+$stream = new ReadableResourceStream(fopen('archive.tar', 'r'));
 
 $decoder = new Decoder();
 
@@ -42,8 +45,6 @@ $decoder->on('entry', function (array $header, React\Stream\ReadableStreamInterf
 });
 
 $stream->pipe($decoder);
-
-$loop->run();
 ```
 
 See also the [examples](examples).
@@ -78,7 +79,7 @@ $ composer install
 To run the test suite, go to the project root and run:
 
 ```bash
-$ php vendor/bin/phpunit
+$ vendor/bin/phpunit
 ```
 
 ## License

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     ],
     "require": {
         "php": ">=5.3",
-        "react/stream": "^1.0 || ^0.7"
+        "react/stream": "^1.2"
     },
     "require-dev": {
         "clue/hexdump": "~0.2.0",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+        "react/event-loop": "^1.2",
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     },
     "autoload": {

--- a/examples/dump.php
+++ b/examples/dump.php
@@ -2,7 +2,6 @@
 
 use Clue\Hexdump\Hexdump;
 use Clue\React\Tar\Decoder;
-use React\EventLoop\Factory;
 use React\Stream\ReadableResourceStream;
 use React\Stream\ReadableStreamInterface;
 
@@ -11,8 +10,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $in = isset($argv[1]) ? $argv[1] : (__DIR__ . '/../tests/fixtures/alice-bob.tar');
 echo 'Reading file "' . $in . '" (pass as argument to example)' . PHP_EOL;
 
-$loop = Factory::create();
-$stream = new ReadableResourceStream(fopen($in, 'r'), $loop);
+$stream = new ReadableResourceStream(fopen($in, 'r'));
 
 $decoder = new Decoder();
 $decoder->on('entry', function (array $header, ReadableStreamInterface $file) {
@@ -41,5 +39,3 @@ $decoder->on('close', function() {
 });
 
 $stream->pipe($decoder);
-
-$loop->run();

--- a/tests/FunctionalDecoderTest.php
+++ b/tests/FunctionalDecoderTest.php
@@ -3,7 +3,7 @@
 namespace Clue\Tests\React\Tar;
 
 use Clue\React\Tar\Decoder;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Stream\ReadableResourceStream;
 
 class FunctionDecoderTest extends TestCase
@@ -16,7 +16,6 @@ class FunctionDecoderTest extends TestCase
     public function setUpDecoderAndLoop()
     {
         $this->decoder = new Decoder();
-        $this->loop = Factory::create();
     }
 
     /**
@@ -28,7 +27,7 @@ class FunctionDecoderTest extends TestCase
 
         $stream->pipe($this->decoder);
 
-        $this->loop->run();
+        Loop::run();
     }
 
     /**
@@ -41,7 +40,7 @@ class FunctionDecoderTest extends TestCase
 
         $stream->pipe($this->decoder);
 
-        $this->loop->run();
+        Loop::run();
     }
 
     public function testStreamingSingleEmptyEmitsSingleEntryWithEmptyStream()
@@ -69,7 +68,7 @@ class FunctionDecoderTest extends TestCase
 
         $stream->pipe($this->decoder);
 
-        $this->loop->run();
+        Loop::run();
     }
 
     public function testCompleteEndSingleEmtpyBehavesSameAsStreaming()
@@ -83,6 +82,6 @@ class FunctionDecoderTest extends TestCase
 
     private function createStream($name, $readChunkSize = null)
     {
-        return new ReadableResourceStream(fopen(__DIR__ . '/fixtures/' . $name, 'r'), $this->loop, $readChunkSize);
+        return new ReadableResourceStream(fopen(__DIR__ . '/fixtures/' . $name, 'r'), null, $readChunkSize);
     }
 }


### PR DESCRIPTION
This changeset simplifies examples and tests by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).

Builds on top of reactphp/event-loop#226, reactphp/event-loop#229, reactphp/event-loop#232 and reactphp/stream#159