### PR TITLE
Rename Decoder to TarDecoder to avoid ambiguities

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ processing one chunk at a time in memory without having to rely on disk I/O.
 ## Quickstart example
 
 Once [installed](#install), you can use the following code to pipe a readable
-tar stream into the `Decoder` which emits "entry" events for each individual file:
+tar stream into the `TarDecoder` which emits "entry" events for each individual file:
 
 ```php
 <?php
@@ -33,7 +33,7 @@ require __DIR__ . '/vendor/autoload.php';
 
 $stream = new React\Stream\ReadableResourceStream(fopen('archive.tar', 'r'));
 
-$decoder = new Clue\React\Tar\Decoder();
+$decoder = new Clue\React\Tar\TarDecoder();
 
 $decoder->on('entry', function (array $header, React\Stream\ReadableStreamInterface $file) {
     echo 'File ' . $header['filename'];

--- a/examples/dump.php
+++ b/examples/dump.php
@@ -7,7 +7,7 @@ echo 'Reading file "' . $in . '" (pass as argument to example)' . PHP_EOL;
 
 $stream = new React\Stream\ReadableResourceStream(fopen($in, 'r'));
 
-$decoder = new Clue\React\Tar\Decoder();
+$decoder = new Clue\React\Tar\TarDecoder();
 $decoder->on('entry', function (array $header, React\Stream\ReadableStreamInterface $file) {
     static $i = 0;
     echo 'FILE #' . ++$i . PHP_EOL;

--- a/src/TarDecoder.php
+++ b/src/TarDecoder.php
@@ -18,7 +18,7 @@ use RuntimeException;
  * @event error(Exception $e)
  * @event close()
  */
-class Decoder extends EventEmitter implements WritableStreamInterface
+class TarDecoder extends EventEmitter implements WritableStreamInterface
 {
     private $buffer = '';
     private $writable = true;

--- a/tests/FunctionalTarDecoderTest.php
+++ b/tests/FunctionalTarDecoderTest.php
@@ -2,20 +2,20 @@
 
 namespace Clue\Tests\React\Tar;
 
-use Clue\React\Tar\Decoder;
+use Clue\React\Tar\TarDecoder;
 use React\EventLoop\Loop;
 use React\Stream\ReadableResourceStream;
 
-class FunctionDecoderTest extends TestCase
+class FunctionalTarDecoderTest extends TestCase
 {
     private $decoder;
 
     /**
      * @before
      */
-    public function setUpDecoderAndLoop()
+    public function setUpTarDecoderAndLoop()
     {
-        $this->decoder = new Decoder();
+        $this->decoder = new TarDecoder();
     }
 
     /**

--- a/tests/TarDecoderTest.php
+++ b/tests/TarDecoderTest.php
@@ -2,20 +2,20 @@
 
 namespace Clue\Tests\React\Tar;
 
-use Clue\React\Tar\Decoder;
+use Clue\React\Tar\TarDecoder;
 use React\Stream\ThroughStream;
 use React\Stream\ReadableStreamInterface;
 
-class DecoderTest extends TestCase
+class TarDecoderTest extends TestCase
 {
     private $decoder;
 
     /**
      * @before
      */
-    public function setUpDecoder()
+    public function setUpTarDecoder()
     {
-        $this->decoder = new Decoder();
+        $this->decoder = new TarDecoder();
     }
 
     public function testWriteLessDataThanBufferSizeWillNotEmitAnyEvents()


### PR DESCRIPTION
This pull request changes the naming of the current `Decoder()` to `TarDecoder()`. The reason behind this is that we use the names "Encoder" and "Decoder" across multiple projects, such as https://github.com/clue/reactphp-csv and others. Using multiple of these repositories in one project can make it hard to differentiate between multiple Encoder and Decoder, so this PR helps to avoid any ambiguities in the future.
 
```php
// old
$decoder = new Clue\React\Tar\Decoder();

// new
$decoder = new Clue\React\Tar\TarDecoder();
```

Builds on top of https://github.com/clue-access/reactphp-tsv/pull/9 and others